### PR TITLE
fix(core): keep a cache of event handlers

### DIFF
--- a/src/createWCProto.js
+++ b/src/createWCProto.js
@@ -24,9 +24,13 @@ function isArray (i) {
  */
 export default (virtualDOMPatcher, component) => {
   const {update, view, init} = component
-  return ({
+  return {
     __dispatchActions (type) {
-      return (params) => this.__store.dispatch({type, params})
+      if (!this.__handlers[type]) {
+        this.__handlers[type] = (params) =>
+          this.__store.dispatch({type, params})
+      }
+      return this.__handlers[type]
     },
     __reducer (state, action) {
       const output = update(state, action)
@@ -48,9 +52,10 @@ export default (virtualDOMPatcher, component) => {
       this.__store = createStore(this.__reducer.bind(this), init(this))
       this.__render()
       this.__dispose = this.__store.subscribe(() => this.__render())
+      this.__handlers = {}
     },
     detachedCallback () {
       this.__dispose()
     }
-  })
+  }
 }

--- a/src/createWCProto.js
+++ b/src/createWCProto.js
@@ -41,18 +41,20 @@ export default (virtualDOMPatcher, component) => {
     __render () {
       this.__patch(view(
         this.__store.getState(),
-        this.__dispatchActions.bind(this)
+        this.__dispatchActions
       ))
     },
     attributeChangedCallback (name, old, params) {
       this.__store.dispatch({type: `@@attr/${name}`, params})
     },
     createdCallback () {
+      this.__handlers = {}
+      this.__dispatchActions = this.__dispatchActions.bind(this)
+
       this.__patch = virtualDOMPatcher(this.createShadowRoot())
       this.__store = createStore(this.__reducer.bind(this), init(this))
       this.__render()
       this.__dispose = this.__store.subscribe(() => this.__render())
-      this.__handlers = {}
     },
     detachedCallback () {
       this.__dispose()

--- a/test/test.createWCProto.js
+++ b/test/test.createWCProto.js
@@ -118,3 +118,16 @@ test('init()', t => {
   wc.createdCallback()
   t.true(init.calledWith(wc))
 })
+test('memoize handler', t => {
+  let dispatch = null
+  const mockPatcher = createMockPatcher()
+  const createShadowRoot = () => '@ROOT'
+  const view = ({count}, _dispatch) => {
+    dispatch = _dispatch
+    return '<div>${count}</div>'
+  }
+  const wc = rwc.createWCProto(mockPatcher.patcher, createMockComponent({view}))
+  wc.createShadowRoot = createShadowRoot
+  wc.createdCallback()
+  t.is(dispatch('XYZ'), dispatch('XYZ'))
+})

--- a/test/test.createWCProto.js
+++ b/test/test.createWCProto.js
@@ -124,7 +124,7 @@ test('memoize handler', t => {
   const createShadowRoot = () => '@ROOT'
   const view = ({count}, _dispatch) => {
     dispatch = _dispatch
-    return '<div>${count}</div>'
+    return `<div>${count}</div>`
   }
   const wc = rwc.createWCProto(mockPatcher.patcher, createMockComponent({view}))
   wc.createShadowRoot = createShadowRoot


### PR DESCRIPTION
changing the event handlers too often can cause a significant performance issue
