### PR TITLE
refactor(core): remove props default getter

### DIFF
--- a/src/createWCProto.js
+++ b/src/createWCProto.js
@@ -62,16 +62,16 @@ export default (virtualDOMPatcher, component) => {
 
     createdCallback () {
       this.__handlers = {}
-      this.__props = {}
+      this.props = {}
       this.__dispatchActions = this.__dispatchActions.bind(this)
       this.__render = this.__render.bind(this)
 
       props.forEach(p => {
-        this.__props[p] = this[p]
+        this.props[p] = this[p]
         Object.defineProperty(this, p, {
-          get: () => this.__props[p],
+          get: () => undefined,
           set: (params) => {
-            this.__props[p] = params
+            this.props[p] = params
             this.__dispatch(`@@rwc/prop/${p}`, params)
           }
         })

--- a/test/test.createWCProto.js
+++ b/test/test.createWCProto.js
@@ -244,7 +244,9 @@ test('createdCallback():copy-initial-values', t => {
   wc['B'] = 'bbb-initial-value'
   wc['C'] = 'ccc-initial-value'
   wc.createdCallback()
-  t.is(wc['A'], 'aaa-initial-value')
-  t.is(wc['B'], 'bbb-initial-value')
+  t.is(wc['A'])
+  t.is(wc['B'])
+  t.is(wc.props['A'], 'aaa-initial-value')
+  t.is(wc.props['B'], 'bbb-initial-value')
   t.is(wc['C'], 'ccc-initial-value')
 })


### PR DESCRIPTION
Default getter returns the last cached prop which causes the virtual dom differ to not set the new property thus skips the prop event. For the system to be successfully reactive change should be detected at component level only and if needed optimizations should be using immutability.

BREAKING CHANGE: props should be accessed via `.props[<prop name>]` and not directly
